### PR TITLE
fixing EYE JITI loss

### DIFF
--- a/src/pl-index.c
+++ b/src/pl-index.c
@@ -295,7 +295,7 @@ firstClause(Word argv, LocalFrame fr, Definition def, ClauseChoice chp ARG_LD)
 	{ best_index->tried_better = new_bitvector(def->functor->arity);
 
 	  for(ci=def->impl.clauses.clause_indexes; ci; ci=ci->next)
-	    set_bit(best_index->tried_better, ci->args[0]-1);
+	    clear_bit(best_index->tried_better, ci->args[0]-1);
 	}
 
 	if ( (best=bestHash(argv, def,


### PR DESCRIPTION
For some particular use cases we experience JITI loss and I made
a simplified case at https://github.com/josd/eyejiti for which
the speed drop is a factor 50.

The proposed is actually fixing the issue and at least all our other
test cases run fine.

The best_index->tried_better_better is created in firstClause(...)
and all the bits cleared and the set_bit happens in bestHash(...).
But we don't claim a full understanding :-)
