### PR TITLE
Extend Emacs behaviour for Emacs-25+

### DIFF
--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -298,6 +298,7 @@ setupGNUEmacsInferiorMode()
   int val;
 
   if ( ((s = Getenv("EMACS", envbuf, sizeof(envbuf))) && s[0]) ||
+       ((s = Getenv("INSIDE_EMACS", envbuf, sizeof(envbuf))) && s[0]) ||
        ((s = Getenv("INFERIOR", envbuf, sizeof(envbuf))) && streq(s, "yes")) )
   { GET_LD
 


### PR DESCRIPTION
For Emacs-25, the EMACS variable will no longer be set by Emacs for inferior shells -- instead, "INSIDE_EMACS" will be used. This frees EMACS to mean "the emacs I want to run".

Currently, Swipl uses the EMACS variable to disable various terminal operations, so should probably be extended to also detect INSIDE_EMACS, so probably needs something like this (untested!) PR.

Thanks!


For Emacs-24 and previous, Emacs uses EMACS=t to identify itself to
internal commands. With Emacs-25 this changes to INSIDE_EMACS variable,
set to a string starting with the version number.