### PR TITLE
Removed obsolete "Last update" line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SWI-Prolog: A comprehensive Prolog implementation
 
-Latest update: May 31, 2016 (Version 7.3.22)
-
 ## Web home
 
 Please find the up-to-date information on SWI-Prolog at


### PR DESCRIPTION
Since SWI Prolog is developed on GitHub there is no point for this line, I think. It's just an additional burden to not to forget updating it all the time. May be a link to releases makes more sense?