### PR TITLE
Include gc(always) in db_sync/1 docs

### DIFF
--- a/library/persistency.pl
+++ b/library/persistency.pl
@@ -573,8 +573,10 @@ set_dirty(Module, Count) :-
 %     Database was re-written, deleting all retractall
 %     statements.  This is the same as gc(50).
 %     * gc(Percentage)
-%     GC DB if the number of deleted terms is the given
+%     GC DB if the number of deleted terms is greater than the given
 %     percentage of the total number of terms.
+%     * gc(always)
+%     GC DB without checking the percentage.
 %     * close
 %     Database stream was closed
 %     * detach


### PR DESCRIPTION
I spotted in the code for db_sync/1 that `When` is first tested to see if it is `always` and thought this would be useful to include in the documentation as I was using `gc(0)` to force the same behaviour, but in a less efficient way.  I added this to the comments for `db_sync/1`, assuming the documentation is generated from this.

If this is useful, and appropriate to the workflow, I can contribute more to the documentation as I work.