### PR TITLE
strip -x to avoid removing global symbols

### DIFF
--- a/library/qsave.pl
+++ b/library/qsave.pl
@@ -1007,7 +1007,7 @@ strip_file(File, Stripped) :-
 strip_file(File, File).
 
 do_strip_file(Strip, File, Stripped) :-
-    format(atom(Cmd), '"~w" -o "~w" "~w"',
+    format(atom(Cmd), '"~w" -x -o "~w" "~w"',
            [Strip, Stripped, File]),
     shell(Cmd),
     exists_file(Stripped).


### PR DESCRIPTION
Without `-x`, `strip` on macOS produces the error:

symbols referenced by indirect symbol table entries that can't be stripped in: <file>

The `-x` flag makes it strip only local symbols on macOS.
This should also work fine on other systems.