### PR TITLE
Update qsave.pl

### DIFF
--- a/library/qsave.pl
+++ b/library/qsave.pl
@@ -238,7 +238,7 @@ make_header(Out, SaveClass, Options) :-
     ->  ArgSep = ' -- '
     ;   ArgSep = ' '
     ),
-    format(Out, 'exec ${SWIPL-~w} -x "$0"~w"$@"~n~n', [Emulator, ArgSep]).
+    format(Out, 'exec ${SWIPL:-~w} -x "$0"~w"$@"~n~n', [Emulator, ArgSep]).
 make_header(_, _, _).
 
 stand_alone(Options) :-


### PR DESCRIPTION
As described in https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02 , a parameter expansion with the format `${parameter-word}` will expand to `parameter` when `parameter` is "Set and Not Null", to `word` when `parameter` is "Unset", but it will expand to `null` when `parameter` is "Set But Null".

This behavior leads to the command `exec  -x "$0" -- "$@"` to be executed when `SWIPL` is set but null.

I do not believe this is the intended behavior. I believe the intended behavior is to keep the `word` expansion when `parameters` is "Set but null".

This patch fixes #26.