### PR TITLE
Fix readln not returning end_of_file atom when stream reaches an end

### DIFF
--- a/library/readln.pl
+++ b/library/readln.pl
@@ -131,7 +131,7 @@ Examples:
 readln(Read) :-                 % the default is read up to EOL
     string_codes("_0123456789", Arg2),
     rl_readln(Line, LastCh, [10], Arg2, uppercase),
-    (   LastCh == -1
+    (   LastCh == end_of_file
     ->  append(Line,[end_of_file], Read)
     ;   Read = Line
     ).


### PR DESCRIPTION
rl_readln now returns end_of_file as it's second argument instead of -1 when it reaches the end of the file.