### PR TITLE
Call gettid via its glibc wrapper if possible

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -343,22 +343,31 @@ check_pthread_setname_np()
 endif(HAVE_PTHREAD_SETNAME_NP)
 
 check_c_source_compiles(
-    "#include <sys/types.h>
-     #include <linux/unistd.h>
+    "#define _GNU_SOURCE
+     #include <unistd.h>
      int main()
-     { _syscall0(pid_t,gettid);
-       return 0;
+     { return gettid();
      }"
-    HAVE_GETTID_MACRO)
-if(NOT HAVE_GETTID_MACRO)
+    HAVE_GETTID_FUNCTION)
+if(NOT HAVE_GETTID_FUNCTION)
   check_c_source_compiles(
-      "#include <unistd.h>
-       #include <sys/syscall.h>
+      "#include <sys/types.h>
+       #include <linux/unistd.h>
        int main()
-       { syscall(__NR_gettid);
-	 return 0;
+       { _syscall0(pid_t,gettid);
+         return 0;
        }"
-      HAVE_GETTID_SYSCALL)
+      HAVE_GETTID_MACRO)
+  if(NOT HAVE_GETTID_FUNCTION AND NOT HAVE_GETTID_MACRO)
+    check_c_source_compiles(
+	"#include <unistd.h>
+	 #include <sys/syscall.h>
+	 int main()
+	 { syscall(__NR_gettid);
+	   return 0;
+	 }"
+        HAVE_GETTID_SYSCALL)
+  endif()
 endif()
 
 endif(CMAKE_USE_PTHREADS_INIT)

--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -125,9 +125,16 @@ APPROACH
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #if defined(__linux__)
+#ifdef HAVE_GETTID_FUNCTION
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <unistd.h>
+#else
 #include <syscall.h>
 #ifdef HAVE_GETTID_MACRO
 _syscall0(pid_t,gettid)
+#endif
 #endif
 #endif
 
@@ -1935,7 +1942,7 @@ set_system_thread_id(PL_thread_info_t *info)
   info->has_tid = TRUE;
 #if defined(HAVE_GETTID_SYSCALL)
   info->pid = syscall(__NR_gettid);
-#elif defined(HAVE_GETTID_MACRO)
+#elif defined(HAVE_GETTID_FUNCTION) || defined(HAVE_GETTID_MACRO)
   info->pid = gettid();
 #elif defined(__CYGWIN__)
   info->pid = getpid();


### PR DESCRIPTION
The gettid wrapper was introduced in glibc 2.30, which was released in 2019.  It does require that `_GNU_SOURCE` be defined when `unistd.h` is included.