### PR TITLE
Make tests pass some more years

### DIFF
--- a/src/Tests/core/test_time.pl
+++ b/src/Tests/core/test_time.pl
@@ -55,7 +55,7 @@ test_time :-
 
 test(get_time) :-
     get_time(Now),
-    assertion(Now > (2018-1970)*365*24*3600),
-    assertion(Now < (2030-1970)*365*24*3600).
+    assertion(Now > (2024-1970)*365*24*3600),
+    assertion(Now < (2050-1970)*365*24*3600).
 
 :- end_tests(time).


### PR DESCRIPTION
Without this patch, tests start to fail after 2029.

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future. The usual offset is +16 years, because that is how long I expect some software will be used in some places. This showed up failing tests in our `swipl` package build. 

See https://reproducible-builds.org/ for why this matters.