### PR TITLE
Adapt to changed semantics of "type f();" in C23

### DIFF
--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -209,7 +209,7 @@ typedef _PLS(PL_local_data) *PL_engine_t; /* opaque engine handle */
 typedef uintptr_t	PL_atomic_t;	/* same a word */
 typedef uintptr_t	foreign_t;	/* return type of foreign functions */
 typedef wchar_t		pl_wchar_t;	/* Prolog wide character */
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ > 201710L
 typedef void *		pl_function_t;      /* pass function as void* */
 #else
 typedef foreign_t	(*pl_function_t)(); /* foreign language functions */


### PR DESCRIPTION
The Fedora project is currently rebuilding all packages with a GCC 15 prerelease.  GCC 15 changes the default C standard from C17 to C23.  In C23, the semantics of `type f();` have changed.  Instead of meaning "a function that returns type with an unspecified parameter list" it now means the same as `type f(void);`; i.e., it asserts that there are no parameters.  This makes the definition of `pl_function_t` not match its use, leading to a compilation error when building the swipy package.

This PR makes C23 use the same definition as C++ for `pl_function_t`.  I have confirmed that the swipy package builds successfully with this change.
